### PR TITLE
fix: Fix information for publish artifact

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -20,9 +20,8 @@ jobs:
     - name: Build
       uses: gradle/gradle-build-action@v2.2.2
       with:
-        arguments: publish
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
-        PUBLISH_MAVEN: true
         REPOSITORY_USERNAME: ${{ secrets.REPOSITORY_USERNAME }}
         REPOSITORY_PASSWORD: ${{ secrets.REPOSITORY_PASSWORD }}
         SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ kotlin.js.generate.executable.default=false
 
 ktorVersion=2.0.3
 ktSerializationVersion=1.3.3
+coroutineVersion=1.6.4


### PR DESCRIPTION
Currently, Sonatype reject my publish because some module don't have information.

This PR allows to add all of the missing information.