### PR TITLE
chore(ci): Add release tag CI

### DIFF
--- a/.github/actions/git/action.yml
+++ b/.github/actions/git/action.yml
@@ -1,0 +1,19 @@
+name: Git user
+description: Set the user information for git usage
+
+inputs:
+  name:
+    description: Name of the git user.
+    required: true
+  email:
+    description: Email of the git user.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set git user information
+      shell: bash
+      run: |
+        git config --global user.name ${{ inputs.name }}
+        git config --global user.email ${{ inputs.email }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,35 @@
+name: Release tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        type: string
+        required: true
+        description: Version to release (major.minor.patch) (example 2.0.1)
+
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Set git user
+        uses: ./.github/actions/git
+        with:
+          name: ${{ secrets.GIT_USER }}
+          email: ${{ secrets.GIT_EMAIL }}
+
+      - name: Initialization
+        uses: ./.github/actions/init
+
+      - name: Release tag
+        uses: gradle/gradle-build-action@v2.2.2
+        with:
+          arguments: release -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=${{ github.event.inputs.releaseVersion }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,6 @@ subprojects {
     apply(plugin = "plugin.serialization")
 }
 
-group = "io.github.universeproject"
-version = "1.0.0"
-description = "Allows interaction with Mojang API using Kotlin and coroutine"
-
 repositories {
     mavenCentral()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+group=io.github.universeproject
+version=1.0.1-SNAPSHOT
+description=Allows interaction with Mojang API using Kotlin and coroutine
+
 kotlin.code.style=official
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false


### PR DESCRIPTION
In order to release the library, we need to trigger a specific plugin when necessary.
The gradle plugin allows to upgrade the version of the library.

# To do
- [x] Create CI to release tag
- [x] Set secrets

After the creation of a tag, a release can be created