### PR TITLE
fix(uuid): Add serializer to unify uuid format

### DIFF
--- a/src/commonMain/kotlin/io/github/universeproject/kotlinmojangapi/MojangData.kt
+++ b/src/commonMain/kotlin/io/github/universeproject/kotlinmojangapi/MojangData.kt
@@ -1,5 +1,6 @@
 package io.github.universeproject.kotlinmojangapi
 
+import io.github.universeproject.kotlinmojangapi.serializer.StringUUIDSerializer
 import io.ktor.util.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -17,7 +18,11 @@ private const val PROPERTY_TEXTURES = "textures"
  * @property id Player's uuid.
  */
 @Serializable
-public data class ProfileId(val name: String, val id: String)
+public data class ProfileId(
+    val name: String,
+    @Serializable(with = StringUUIDSerializer::class)
+    val id: String
+)
 
 /**
  * Expected response of the Mojang api to retrieve name with their change date.
@@ -39,6 +44,7 @@ public data class ProfileName(val name: String, val changedToAt: Long = 0)
  */
 @Serializable
 public data class ProfileSkin(
+    @Serializable(with = StringUUIDSerializer::class)
     val id: String,
     val name: String,
     val properties: List<Property> = emptyList(),
@@ -80,6 +86,7 @@ public data class ProfileSkin(
 @Serializable
 public data class ProfileSkinDecoded(
     val timestamp: Long,
+    @Serializable(with = StringUUIDSerializer::class)
     val profileId: String,
     val profileName: String,
     val textures: Textures

--- a/src/commonMain/kotlin/io/github/universeproject/kotlinmojangapi/extension/StringExt.kt
+++ b/src/commonMain/kotlin/io/github/universeproject/kotlinmojangapi/extension/StringExt.kt
@@ -1,0 +1,31 @@
+package io.github.universeproject.kotlinmojangapi.extension
+
+/**
+ * Regex for a valid uuid string format with dashes.
+ * A valid UUID should be in the format of: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 characters) with only hex characters.
+ */
+private val uuidRegex = "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$".toRegex()
+
+/**
+ * Regex for a valid uuid string format without dashes.
+ * A valid UUID should be in the format of: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (32 characters) with only hex characters.
+ */
+private val uuidWithoutDashesRegex = "^([a-fA-F0-9]{8})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{12})$".toRegex()
+
+/**
+ * Formats a string to a valid uuid string format.
+ * If the string is already formatted, it will return the string.
+ * If the string is in a valid format, but not in the correct format, it will return the formatted string.
+ * If the string is not in a valid format (length, characters, etc), it will throw an [IllegalArgumentException].
+ * @receiver The string to format.
+ * @return The formatted string.
+ */
+public fun String.formatUUID(): String {
+    return if (matches(uuidRegex)) {
+        this
+    } else if(matches(uuidWithoutDashesRegex)) {
+        replace(uuidWithoutDashesRegex, "$1-$2-$3-$4-$5")
+    } else {
+        throw IllegalArgumentException("Invalid UUID format for string: [$this]")
+    }
+}

--- a/src/commonMain/kotlin/io/github/universeproject/kotlinmojangapi/serializer/StringUUIDSerializer.kt
+++ b/src/commonMain/kotlin/io/github/universeproject/kotlinmojangapi/serializer/StringUUIDSerializer.kt
@@ -1,0 +1,26 @@
+package io.github.universeproject.kotlinmojangapi.serializer
+
+import io.github.universeproject.kotlinmojangapi.extension.formatUUID
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Serializer to format a string to a valid uuid string format.
+ * @property stringSerializer The string serializer.
+ * @see formatUUID
+ */
+public object StringUUIDSerializer : KSerializer<String> {
+
+    private val stringSerializer = String.serializer()
+
+    override val descriptor: SerialDescriptor = stringSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: String) {
+        stringSerializer.serialize(encoder, value.formatUUID())
+    }
+
+    override fun deserialize(decoder: Decoder): String = stringSerializer.deserialize(decoder).formatUUID()
+}

--- a/src/jvmTest/kotlin/io/github/universeproject/kotlinmojangapi/MojangAPIImplTest.kt
+++ b/src/jvmTest/kotlin/io/github/universeproject/kotlinmojangapi/MojangAPIImplTest.kt
@@ -89,7 +89,7 @@ class MojangAPIImplTest {
         @Test
         fun `with an existing player name`() = runTest {
             val name = "lukethehacker23"
-            assertEquals(ProfileId(name, "cdb5aee80f904fdda63ba16d38cd6b3b"), mojangApi.getUUID(name))
+            assertEquals(ProfileId(name, "cdb5aee8-0f90-4fdd-a63b-a16d38cd6b3b"), mojangApi.getUUID(name))
         }
 
         @Test
@@ -131,8 +131,8 @@ class MojangAPIImplTest {
         fun `with existing player name`() = runTest {
             assertContentEquals(
                 listOf(
-                    ProfileId("jeb_", "853c80ef3c3749fdaa49938b674adae6"),
-                    ProfileId("Notch", "069a79f444e94726a5befca90e38aaf5")
+                    ProfileId("jeb_", "853c80ef-3c37-49fd-aa49-938b674adae6"),
+                    ProfileId("Notch", "069a79f4-44e9-4726-a5be-fca90e38aaf5")
                 ),
                 mojangApi.getUUID(listOf("Notch", "jeb_"))
             )
@@ -142,7 +142,7 @@ class MojangAPIImplTest {
         fun `with existing and non existing player name`() = runTest {
             assertContentEquals(
                 listOf(
-                    ProfileId("jeb_", "853c80ef3c3749fdaa49938b674adae6"),
+                    ProfileId("jeb_", "853c80ef-3c37-49fd-aa49-938b674adae6"),
                 ),
                 mojangApi.getUUID(listOf(generateRandomName(), "jeb_", generateRandomName()))
             )
@@ -177,7 +177,7 @@ class MojangAPIImplTest {
         @Test
         fun `with an existing player uuid`() = runTest {
             val uuid = "cdb5aee80f904fdda63ba16d38cd6b3b"
-            assertEquals(ProfileId("lukethehacker23", uuid), mojangApi.getName(uuid))
+            assertEquals(ProfileId("lukethehacker23", "cdb5aee8-0f90-4fdd-a63b-a16d38cd6b3b"), mojangApi.getName(uuid))
         }
 
         @Test
@@ -206,7 +206,7 @@ class MojangAPIImplTest {
             val name = "123lmfao4"
             val skin = mojangApi.getSkin(id)
             assertNotNull(skin)
-            assertEquals(id, skin.id)
+            assertEquals("f1bfcbdd-c68b-49bf-aac9-fb9d8ce5293d", skin.id)
             assertEquals(name, skin.name)
 
             val properties = skin.properties
@@ -217,7 +217,7 @@ class MojangAPIImplTest {
             assertNotNull(property.signature)
 
             val decoded = skin.getSkinDecoded()
-            assertEquals(id, decoded.profileId)
+            assertEquals("f1bfcbdd-c68b-49bf-aac9-fb9d8ce5293d", decoded.profileId)
             assertEquals(name, decoded.profileName)
 
             val textures = decoded.textures

--- a/src/jvmTest/kotlin/io/github/universeproject/kotlinmojangapi/extension/StringExtTest.kt
+++ b/src/jvmTest/kotlin/io/github/universeproject/kotlinmojangapi/extension/StringExtTest.kt
@@ -1,0 +1,50 @@
+package io.github.universeproject.kotlinmojangapi.extension
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StringExtTest {
+
+    @Nested
+    inner class FormatUUID {
+
+        @Test
+        fun `should return the same string if it is already formatted`() {
+            repeat(100) {
+                val uuid = UUID.randomUUID().toString()
+                assertEquals(uuid, uuid.formatUUID())
+            }
+        }
+
+        @Test
+        fun `should throw an exception if the string is formatted but with invalid character`() {
+            sequenceOf(
+                "123y5678-1234-1234-1234-123456789012",
+                "12345678-12g4-1234-1234-123456789012",
+                "12345678-1234-12q4-1234-123456789012",
+                "12345678-1234-1234-12x4-123456789012",
+                "12345678-1234-1234-1234-12345678901g"
+            ).forEach {
+                val ex = assertThrows<IllegalArgumentException> { it.formatUUID() }
+                assertEquals("Invalid UUID format for string: [$it]", ex.message)
+            }
+        }
+
+        @Test
+        fun `should return the formatted string with a uuid format`() {
+            val unformatted = "12345678123412341234123456789012"
+            val formatted = "12345678-1234-1234-1234-123456789012"
+            assertEquals(formatted, unformatted.formatUUID())
+        }
+
+        @Test
+        fun `should return the formatted string with a uuid format with uppercase letters`() {
+            val unformatted = "aCfE1234-12X4-1wW4-12F4-123456T89012"
+            val formatted = "aCfE1234-12X4-1wW4-12F4-123456T89012"
+            assertEquals(formatted, unformatted.formatUUID())
+        }
+    }
+}

--- a/src/jvmTest/kotlin/io/github/universeproject/kotlinmojangapi/extension/StringExtTest.kt
+++ b/src/jvmTest/kotlin/io/github/universeproject/kotlinmojangapi/extension/StringExtTest.kt
@@ -42,8 +42,8 @@ class StringExtTest {
 
         @Test
         fun `should return the formatted string with a uuid format with uppercase letters`() {
-            val unformatted = "aCfE1234-12X4-1wW4-12F4-123456T89012"
-            val formatted = "aCfE1234-12X4-1wW4-12F4-123456T89012"
+            val unformatted = "aCfB1234-12A4-1dD4-12F4-123456E89012"
+            val formatted = "aCfB1234-12A4-1dD4-12F4-123456E89012"
             assertEquals(formatted, unformatted.formatUUID())
         }
     }

--- a/src/jvmTest/kotlin/io/github/universeproject/kotlinmojangapi/serializer/StringUUIDSerializerTest.kt
+++ b/src/jvmTest/kotlin/io/github/universeproject/kotlinmojangapi/serializer/StringUUIDSerializerTest.kt
@@ -1,0 +1,111 @@
+package io.github.universeproject.kotlinmojangapi.serializer
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StringUUIDSerializerTest {
+
+    @Nested
+    inner class Serialize {
+
+        @Test
+        fun `should serialize a valid uuid with dashes`() {
+            val uuid = UUID.randomUUID().toString()
+            val serializer = StringUUIDSerializer
+            assertEquals(stringWrappedInQuotes(uuid), Json.encodeToString(serializer, uuid))
+        }
+
+        @Test
+        fun `should serialize a valid uuid without dashes`() {
+            val expected = UUID.randomUUID().toString()
+            val uuidWithoutDashes = expected.replace("-", "")
+            val serializer = StringUUIDSerializer
+            assertEquals(stringWrappedInQuotes(expected), Json.encodeToString(serializer, uuidWithoutDashes))
+        }
+
+        @Test
+        fun `should serialize a valid uuid with uppercase letters and with dashes`() {
+            val expected = UUID.randomUUID().toString().uppercase(Locale.getDefault())
+            val serializer = StringUUIDSerializer
+            assertEquals(stringWrappedInQuotes(expected), Json.encodeToString(serializer, expected))
+        }
+
+        @Test
+        fun `should serialize a valid uuid with uppercase letters and without dashes`() {
+            val expected = UUID.randomUUID().toString().uppercase(Locale.getDefault())
+            val uuidWithoutDashes = expected.replace("-", "")
+            val serializer = StringUUIDSerializer
+            assertEquals(stringWrappedInQuotes(expected), Json.encodeToString(serializer, uuidWithoutDashes))
+        }
+
+        @Test
+        fun `should throw an exception if the string is formatted but with invalid character`() {
+            sequenceOf(
+                "123y5678-1234-1234-1234-123456789012",
+                "12345678-12g4-1234-1234-123456789012",
+                "12345678-1234-12q4-1234-123456789012",
+                "12345678-1234-1234-12x4-123456789012",
+                "12345678-1234-1234-1234-12345678901g"
+            ).forEach {
+                assertThrows<IllegalArgumentException> { Json.encodeToString(StringUUIDSerializer, it) }
+            }
+        }
+
+        private fun stringWrappedInQuotes(string: String) = "\"$string\""
+
+    }
+
+    @Nested
+    inner class Deserialize {
+
+        @Test
+        fun `should deserialize a valid uuid with dashes`() {
+            val uuid = UUID.randomUUID().toString()
+            val serializer = StringUUIDSerializer
+            assertEquals(uuid, Json.decodeFromString(serializer, wrappedInQuotes(uuid)))
+        }
+
+        @Test
+        fun `should deserialize a valid uuid without dashes`() {
+            val expected = UUID.randomUUID().toString()
+            val uuidWithoutDashes = expected.replace("-", "")
+            val serializer = StringUUIDSerializer
+            assertEquals(expected, Json.decodeFromString(serializer, wrappedInQuotes(uuidWithoutDashes)))
+        }
+
+        @Test
+        fun `should deserialize a valid uuid with uppercase letters and with dashes`() {
+            val expected = UUID.randomUUID().toString().uppercase(Locale.getDefault())
+            val serializer = StringUUIDSerializer
+            assertEquals(expected, Json.decodeFromString(serializer, wrappedInQuotes(expected)))
+        }
+
+        @Test
+        fun `should deserialize a valid uuid with uppercase letters and without dashes`() {
+            val expected = UUID.randomUUID().toString().uppercase(Locale.getDefault())
+            val uuidWithoutDashes = expected.replace("-", "")
+            val serializer = StringUUIDSerializer
+            assertEquals(expected, Json.decodeFromString(serializer, wrappedInQuotes(uuidWithoutDashes)))
+        }
+
+        @Test
+        fun `should throw an exception if the string is formatted but with invalid character`() {
+            sequenceOf(
+                "123y5678-1234-1234-1234-123456789012",
+                "12345678-12g4-1234-1234-123456789012",
+                "12345678-1234-12q4-1234-123456789012",
+                "12345678-1234-1234-12x4-123456789012",
+                "12345678-1234-1234-1234-12345678901g"
+            ).forEach {
+                assertThrows<IllegalArgumentException> { Json.decodeFromString(StringUUIDSerializer, wrappedInQuotes(it)) }
+            }
+        }
+
+        private fun wrappedInQuotes(string: String) = "\"$string\""
+
+    }
+}


### PR DESCRIPTION
# Context

The mojang API should returns the UUID without dashes. However, it's not a valid UUID format in lot of software.
To fix that, each serialization of ids is transformed to apply dashes in string.

# To do

- [x] Apply dashes in string uuid when necessary
- [x] Tests